### PR TITLE
Add publisher and repository fields to package.json

### DIFF
--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -3,6 +3,11 @@
   "displayName": "SCIP LSP Extension",
   "description": "SCIP based language server with support for Bazel",
   "version": "0.0.1",
+  "publisher": "uber",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uber/scip-lsp.git"
+  },
   "license": "MIT",
   "engines": {
     "vscode": "^1.90.0"


### PR DESCRIPTION
## Description

Adds a publisher and repository information to the package.json file. Resolves the issue of having a strange extension ID.

Before the change
<img width="365" height="194" alt="image" src="https://github.com/user-attachments/assets/65806edc-1ef8-469b-8c85-0fe7cd320376" />

After the change
<img width="380" height="228" alt="image" src="https://github.com/user-attachments/assets/96dd6a3b-e379-4dbf-800a-e249dd6e48fe" />



## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Component(s) Affected

- [ ] Language Server (ULSP)
- [ ] SCIP Generation (Python utilities)
- [x] VS Code/Cursor Extension
- [ ] Java Aggregator
- [ ] Build System (Bazel)
- [ ] Documentation
- [ ] Tests

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`bazel test //...`)
- [x] I have tested this manually with a real project

### Manual Testing Details

Describe how you tested these changes:
- IDE used for testing: vscode
- Project(s) tested against: internal company repo
- Specific features/scenarios verified: extension metadata

## Checklist

- [ ] My code follows the existing code style and conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated BUILD.bazel files if I added new source files
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots/Logs (if applicable)


Can see reflected metadata.
<img width="380" height="228" alt="image" src="https://github.com/user-attachments/assets/96dd6a3b-e379-4dbf-800a-e249dd6e48fe" />

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Additional Notes

Any additional information that reviewers should know about this PR.