### PR TITLE
[bsp_server/indexer] update output paths using jar.short_path

### DIFF
--- a/bsp_server/indexer/scip.bzl
+++ b/bsp_server/indexer/scip.bzl
@@ -127,7 +127,7 @@ def _scip_java(target, ctx):
             for jar in rule_jars:
                 # Mimic arguments from java decompiler plugin in Intellij
                 # mirror: https://github.com/fesh0r/fernflower
-                decompiled_jar = ctx.actions.declare_file(jar.short_path + "_dec.jar")
+                decompiled_jar = ctx.actions.declare_file("out/" + jar.short_path + "_dec.jar")
                 args = [
                     "-target_file=" + decompiled_jar.path,
                     "-timeout=" + timeout,
@@ -219,7 +219,7 @@ def _index_sources(
     return [scip_file_mutated, sha256_file]
 
 def _index_jar(ctx, target, jar, flow_prefix = "_index_jar"):
-    unpacked = ctx.actions.declare_directory(jar.short_path + flow_prefix + "-unpacked")
+    unpacked = ctx.actions.declare_directory("out/" + jar.short_path + flow_prefix + "-unpacked")
     ctx.actions.run_shell(
         inputs = [jar],
         outputs = [unpacked],
@@ -234,7 +234,7 @@ def _index_jar(ctx, target, jar, flow_prefix = "_index_jar"):
         progress_message = "Extracting jar {jar}".format(jar = jar.path),
     )
 
-    sources_file = ctx.actions.declare_file(jar.short_path + "_sources.txt")
+    sources_file = ctx.actions.declare_file("out/" + jar.short_path + "_sources.txt")
     ctx.actions.run_shell(
         command = """
             touch "{sources_file}";


### PR DESCRIPTION
## Description

Adds an additional "out/" directory prefix in the generated scip files making use of `jar.short_path` as part of the declared output path.

This fixes a bug when the label is an alias to the jar (or multiple levels of aliases + select statements). In some circumstances Bazel will error indicating that the delcared file or directory is not within the same package, triggering [this](https://sourcegraph.com/github.com/bazelbuild/bazel@8a232d1d70bc767976d92fd10aeaeb0b770cdb4d/-/blob/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkActionFactory.java?L1190-1194) error. This is remediated simply by declaring a relative `"out/"` prefix on the path.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Component(s) Affected

- [ ] Language Server (ULSP)
- [x] SCIP Generation (Python utilities)
- [ ] VS Code/Cursor Extension
- [ ] Java Aggregator
- [ ] Build System (Bazel)
- [ ] Documentation
- [ ] Tests

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`bazel test //...`)
- [x] I have tested this manually with a real project

### Manual Testing Details

Describe how you tested these changes:
- IDE used for testing: VS Code
- Project(s) tested against: Internal company repository
- Specific features/scenarios verified: Sync and code-generation with targets through `alias` and `select` indirection, within and outside of the main repostiory/workspace.

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated BUILD.bazel files if I added new source files
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots/Logs (if applicable)

Include any relevant screenshots, logs, or output that demonstrates the changes.

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Additional Notes

Any additional information that reviewers should know about this PR.