### PR TITLE
[bsp_server/indexer] Small fixes to bazel aspect

### DIFF
--- a/bsp_server/indexer/scip.bzl
+++ b/bsp_server/indexer/scip.bzl
@@ -163,10 +163,15 @@ def _index_sources(
         ctx,
         target,
         sources_file,
-        sources_folders = [],
+        sources_folders = None
         inputs = depset(),
-        additional_classpath = [],
+        additional_classpath = None,
         flow_prefix = "_index_sources"):
+    if source_folders == None:
+        source_folders = []
+    if additional_classpath == None:
+        additional_classpath = []
+
     classpath = _get_classpath_from_target(ctx, target, flow_prefix)
     indexer = ctx.executable._java_aggregate_binary
     sematicdb_javac_plugin = ctx.attr._javac_semanticdb_plugin[DefaultInfo].files.to_list()[0]
@@ -207,6 +212,7 @@ def _index_sources(
     sha256_file = ctx.actions.declare_file(scip_file_mutated_label + ".sha256")
     ctx.actions.run_shell(
         inputs = [scip_file_mutated],
+        progress_message = "Generating SHA256 hash for %s" % ctx.label.package + ":" + ctx.label.name,
         outputs = [sha256_file],
         command = "shasum -a 256 {} | cut -d' ' -f1 > {}".format(
             scip_file_mutated.path,


### PR DESCRIPTION
## Description

- Removed instances of unused variables
- Removed named parameter in `setdefault` (resolves buildifier lint on improper usage)
- Removed usage of mutable default parameters
- Adds generated class jars when compilation_info is empty

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Component(s) Affected

- [ ] Language Server (ULSP)
- [x] SCIP Generation (Python utilities)
- [ ] VS Code/Cursor Extension
- [ ] Java Aggregator
- [ ] Build System (Bazel)
- [ ] Documentation
- [ ] Tests

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`bazel test //...`)
- [x] I have tested this manually with a real project

### Manual Testing Details

Describe how you tested these changes:
- IDE used for testing: VS Code
- Project(s) tested against: Internal company repositories
- Specific features/scenarios verified: scip file generation (via invoking the scip_sync in bsp_serverfi

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated BUILD.bazel files if I added new source files
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

## Screenshots/Logs (if applicable)

Include any relevant screenshots, logs, or output that demonstrates the changes.

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Additional Notes

Currently we're not returning generated class jars when the compilation_info is missing, which may make sense if we're only considering annotation-processor generated code from java rules. However this may not account for custom rules that perform Java/JVM code generation and, similar to the Scala rules, are also missing compilation_info.

We're already doing the work to collect any classes, so I'm not seeing any harm here in returning this information.