### PR TITLE
Swap UBER_CONFIG_DIR for ULSP_CONFIG_DIR

### DIFF
--- a/src/extension/src/lspclient.ts
+++ b/src/extension/src/lspclient.ts
@@ -265,9 +265,9 @@ export class LSPClient {
       'INFO: Initializing a new server process. See output in "Uber LSP Server Initialization" channel.'
     )
 
-    // Bazel depends on the parent process environment, as well as additional UBER_CONFIG_DIR needed to launch service.
+    // Bazel depends on the parent process environment, as well as additional ULSP_CONFIG_DIR needed to launch service.
     const currentEnv = {...process.env}
-    currentEnv.UBER_CONFIG_DIR = this.serverLaunchConfig?.configDir
+    currentEnv.ULSP_CONFIG_DIR = this.serverLaunchConfig?.configDir
 
     // Process will be detached, so write stdout and stderr to a temporary file.
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ulsp-'))

--- a/src/ulsp/README.md
+++ b/src/ulsp/README.md
@@ -8,20 +8,20 @@ The Extension will attempt to launch its own instance of the ulsp service from t
 1. Add this settings `"uber.uberLanguageServer.serverDevelopmentMode": true` into your VS Code settings.json to prevent relaunch of ulsp daemon by vscode-devportal extension.
 2. Check for any existing running ulsp process (`ps -aux | grep ulsp`) and terminate if necessary.
 3. Launch the service by running one of the following from the root of the service directory.
-   - `$ ULSP_ENVIRONMENT=development UBER_CONFIG_DIR=$PWD/config bazel run .`
-   - `$ ULSP_ENVIRONMENT=development UBER_CONFIG_DIR=$PWD/config bazel debug .`
+   - `$ ULSP_ENVIRONMENT=development ULSP_CONFIG_DIR=$PWD/config bazel run .`
+   - `$ ULSP_ENVIRONMENT=development ULSP_CONFIG_DIR=$PWD/config bazel debug .`
 4. Open a separate IDE session with the Uber Dev Portal extension installed.  The IDE will connect to the running instance and begin sending requests to ulsp, which will appear in the terminal output from ulsp when running it in development mode.  The service will pause at breakpoints if launched in debug mode.
 5. If you make changes to ulsp and restart it, you can trigger the IDE to re-connect to the updated service by running `Cmd+Shift+P -> Developer: Reload Window` which will cause the IDE to re-establish the LSP connection.
 
 
 ### To launch current deployed version
 Same steps as above, except use the following command to launch via uexec:
-   - `$ ULSP_ENVIRONMENT=development UBER_CONFIG_DIR=~/go-code/src/ulsp/config uexec ~/go-code/tools/ide/ulsp/ulsp-daemon`
+   - `$ ULSP_ENVIRONMENT=development ULSP_CONFIG_DIR=~/go-code/src/ulsp/config uexec ~/go-code/tools/ide/ulsp/ulsp-daemon`
 
-UBER_CONFIG_DIR can be pointed to another path if different configs are to be used, and may include multiple colon-separated paths if configs may be in multiple locations.
+ULSP_CONFIG_DIR can be pointed to another path if different configs are to be used, and may include multiple colon-separated paths if configs may be in multiple locations.
 
 ### Service Configs
-Configurations are selected based on the provided UBER_CONFIG_DIR location, and ULSP_ENVIRONMENT value.
+Configurations are selected based on the provided ULSP_CONFIG_DIR location, and ULSP_ENVIRONMENT value.
 - base.yaml is always used as the base
 - if ULSP_ENVIRONMENT is set to `development`, the development.yaml config will applied on top of the base config.
 - otherwise, devpod.yaml or local.yaml will be applied on top of the base config based on current environment.

--- a/src/ulsp/app/BUILD.bazel
+++ b/src/ulsp/app/BUILD.bazel
@@ -30,7 +30,7 @@ go_test(
     srcs = ["decorators_test.go"],
     data = ["//src/ulsp/app/testdata/config"],
     embed = [":go_default_library"],
-    env = {"UBER_CONFIG_DIR": "testdata/config"},
+    env = {"ULSP_CONFIG_DIR": "testdata/config"},
     deps = [
         "//src/ulsp/internal/executor:go_default_library",
         "//src/ulsp/internal/executor:go_loader_gomock_library",

--- a/src/ulsp/config/meta.yaml
+++ b/src/ulsp/config/meta.yaml
@@ -9,6 +9,6 @@ files:
   # development.yaml, devpod.yaml, or local.yaml based on logic in ulsp-daemon/app/decorators.go
   - ${UBER_ENVIRONMENT:local}.yaml
   # user.yaml is the last file to be loaded, allowing user modification of specific keys.
-  # To read it from a separate directory, include multiple colon-separated paths in UBER_CONFIG_DIR
+  # To read it from a separate directory, include multiple colon-separated paths in ULSP_CONFIG_DIR
   # For example, /main/config/dir/config:/home/user/.devexp/config
   - user.yaml


### PR DESCRIPTION
## Description

The ulsp-deamon is expecting `ULSP_CONFIG_DIR`, but the extension was setting `UBER_CONFIG_DIR` resulting in the default being used (which is a path relative to the current working directory). This also meant that the vscode extension option `"uber.uberLanguageServer.serverConfigDirectory"` was non-functional.

This change replaces all mention of the `UBER_CONFIG_DIR` for `ULSP_CONFIG_DIR` in the project.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Component(s) Affected

- [ ] Language Server (ULSP)
- [ ] SCIP Generation (Python utilities)
- [x] VS Code/Cursor Extension
- [ ] Java Aggregator
- [ ] Build System (Bazel)
- [x] Documentation
- [x] Tests

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`bazel test //...`)
- [x] I have tested this manually with a real project

### Manual Testing Details

Describe how you tested these changes:
- IDE used for testing: VS Code
- Project(s) tested against: Stripe internal repositories
- Specific features/scenarios verified: Extension activation / ulsp-daemon initialization

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have updated BUILD.bazel files if I added new source files
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots/Logs (if applicable)

Include any relevant screenshots, logs, or output that demonstrates the changes.

## Related Issues

Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

## Additional Notes

Any additional information that reviewers should know about this PR.