### PR TITLE
feat(scip-lib): Add symbol visited callback

### DIFF
--- a/src/scip-lib/partialloader/index.go
+++ b/src/scip-lib/partialloader/index.go
@@ -146,6 +146,24 @@ func (p *PartialLoadedIndex) LoadIndex(indexPath string, indexReader scanner.Sci
 	localDocToIndex := make(map[string]string)
 	localImplementorsBySymbol := make(map[string]map[string]struct{})
 
+	// Dispatch onSymbolVisited callbacks on a worker goroutine so the scanner's
+	// critical path is never blocked by consumer work. The channel is buffered
+	// to absorb short bursts; the worker is joined before LoadIndex returns so
+	// consumers see all events by the time the call completes.
+	type symbolEvent struct {
+		docPath string
+		info    *model.SymbolInformation
+	}
+	symbolCh := make(chan symbolEvent, 256)
+	var workerWg sync.WaitGroup
+	workerWg.Add(1)
+	go func() {
+		defer workerWg.Done()
+		for ev := range symbolCh {
+			p.onSymbolVisited(ev.docPath, ev.info)
+		}
+	}()
+
 	loadScanner := &scanner.IndexScannerImpl{
 		Pool: p.pool,
 		MatchSymbol: func(symbol []byte) bool {
@@ -187,7 +205,7 @@ func (p *PartialLoadedIndex) LoadIndex(indexPath string, indexReader scanner.Sci
 				localDocTreeNodes[docPath].nodes = append(localDocTreeNodes[docPath].nodes, leafNode)
 			}
 
-			p.onSymbolVisited(docPath, modelInfo)
+			symbolCh <- symbolEvent{docPath, modelInfo}
 		},
 		VisitDocument: func(doc *scip.Document) {
 			docPath := filepath.Clean(doc.RelativePath)
@@ -201,6 +219,8 @@ func (p *PartialLoadedIndex) LoadIndex(indexPath string, indexReader scanner.Sci
 
 	loadScanner.InitBuffers()
 	defer func() {
+		close(symbolCh)
+		workerWg.Wait()
 		p.modificationMu.Lock()
 		defer p.modificationMu.Unlock()
 		p.mergePrefixTree(localPrefixTree)

--- a/src/scip-lib/partialloader/index.go
+++ b/src/scip-lib/partialloader/index.go
@@ -18,6 +18,7 @@ import (
 // PartialIndex is a partial index of a SCIP index
 type PartialIndex interface {
 	SetDocumentLoadedCallback(func(*model.Document))
+	SetSymbolVisitedCallback(func(docPath string, info *model.SymbolInformation))
 	LoadIndex(indexPath string, indexReader scanner.ScipReader) error
 	LoadIndexFile(file string) error
 	LoadDocument(relativeDocPath string) (*model.Document, error)
@@ -58,6 +59,7 @@ type PartialLoadedIndex struct {
 	indexFolder      string
 	pool             *scanner.BufferPool
 	onDocumentLoaded func(*model.Document)
+	onSymbolVisited  func(docPath string, info *model.SymbolInformation)
 
 	// ImplementorsBySymbol maps abstract/interface symbol -> set of implementing symbols
 	implementorsMu       sync.RWMutex
@@ -75,6 +77,7 @@ func NewPartialLoadedIndex(indexFolder string) PartialIndex {
 		indexFolder:          indexFolder,
 		pool:                 scanner.NewBufferPool(1024, 12),
 		onDocumentLoaded:     func(*model.Document) {},
+		onSymbolVisited:      func(string, *model.SymbolInformation) {},
 		ImplementorsBySymbol: make(map[string]map[string]struct{}),
 	}
 }
@@ -82,6 +85,11 @@ func NewPartialLoadedIndex(indexFolder string) PartialIndex {
 // SetDocumentLoadedCallback sets the callback for when a document is loaded
 func (p *PartialLoadedIndex) SetDocumentLoadedCallback(callback func(*model.Document)) {
 	p.onDocumentLoaded = callback
+}
+
+// SetSymbolVisitedCallback sets the callback for when a symbol is visited during index scanning
+func (p *PartialLoadedIndex) SetSymbolVisitedCallback(callback func(docPath string, info *model.SymbolInformation)) {
+	p.onSymbolVisited = callback
 }
 
 // LoadIndexFile loads a SCIP index file into the PartialLoadedIndex
@@ -178,6 +186,8 @@ func (p *PartialLoadedIndex) LoadIndex(indexPath string, indexReader scanner.Sci
 			if isNew {
 				localDocTreeNodes[docPath].nodes = append(localDocTreeNodes[docPath].nodes, leafNode)
 			}
+
+			p.onSymbolVisited(docPath, modelInfo)
 		},
 		VisitDocument: func(doc *scip.Document) {
 			docPath := filepath.Clean(doc.RelativePath)

--- a/src/scip-lib/partialloader/index_test.go
+++ b/src/scip-lib/partialloader/index_test.go
@@ -411,6 +411,22 @@ func TestLoadIndexWithPreloadedDocument(t *testing.T) {
 	assert.Equal(t, docPath, foundDocPath)
 }
 
+func TestSetSymbolVisitedCallback(t *testing.T) {
+	index := NewPartialLoadedIndex("../testdata")
+
+	symbolCount := 0
+	index.SetSymbolVisitedCallback(func(docPath string, info *model.SymbolInformation) {
+		symbolCount++
+		assert.NotEmpty(t, docPath)
+		assert.NotNil(t, info)
+		assert.NotEmpty(t, info.Symbol)
+	})
+
+	err := index.LoadIndexFile(filepath.Join("../testdata", "index.scip"))
+	assert.NoError(t, err)
+	assert.Greater(t, symbolCount, 0, "Callback should be called for each symbol in the index")
+}
+
 // New tests for reverse implementors index
 func TestMergeImplementors(t *testing.T) {
 	idx := &PartialLoadedIndex{

--- a/src/scip-lib/registry/partial_registry.go
+++ b/src/scip-lib/registry/partial_registry.go
@@ -47,6 +47,10 @@ func (p *partialScipRegistry) SetDocumentLoadedCallback(callback func(*model.Doc
 	p.Index.SetDocumentLoadedCallback(callback)
 }
 
+func (p *partialScipRegistry) SetSymbolVisitedCallback(callback func(docPath string, info *model.SymbolInformation)) {
+	p.Index.SetSymbolVisitedCallback(callback)
+}
+
 func (p *partialScipRegistry) DidOpen(uri uri.URI, text string) error {
 	relativePath := p.uriToRelativePath(uri)
 

--- a/src/scip-lib/registry/types.go
+++ b/src/scip-lib/registry/types.go
@@ -15,6 +15,7 @@ type PackageID string
 type Registry interface {
 	LoadConcurrency() int
 	SetDocumentLoadedCallback(func(*model.Document))
+	SetSymbolVisitedCallback(func(docPath string, info *model.SymbolInformation))
 	LoadIndex(indexReader io.ReadSeeker) error
 	LoadIndexFile(indexPath string) error
 	DidOpen(uri uri.URI, text string) error


### PR DESCRIPTION
## Description
**What**:
- Add a callback that fires for every non-local symbol during index scanning.
- Expose it through both the partial loader and registry layers.

**Why**:
- Allow consumers to build auxiliary data structures (e.g., search indices) from all symbols as SCIP files are scanned, without requiring a second pass over the file.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Component(s) Affected

- [x] Language Server (ULSP)
- [ ] SCIP Generation (Python utilities)
- [ ] VS Code/Cursor Extension
- [ ] Java Aggregator
- [ ] Build System (Bazel)
- [ ] Documentation
- [x] Tests

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`bazel test //...`)
- [ ] I have tested this manually with a real project

### Manual Testing Details

Describe how you tested these changes:
- IDE used for testing: N/A
- Project(s) tested against: N/A
- Specific features/scenarios verified: N/A

## Checklist

- [x] My code follows the existing code style and conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have updated BUILD.bazel files if I added new source files
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots/Logs (if applicable)

N/A

## Related Issues

N/A

## Additional Notes

This is a breaking interface change; any external implementations of `PartialIndex` or `Registry` will need to add the new method. The callback mirrors the existing `SetDocumentLoadedCallback` pattern.